### PR TITLE
enable sf again, remove compiled geos

### DIFF
--- a/3.3.1/Dockerfile
+++ b/3.3.1/Dockerfile
@@ -77,7 +77,7 @@ RUN wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar
     rgdal \
     rgeos \
     rlas \
-#    sf \
+    sf \
     sp \
     spacetime \
     spatstat \

--- a/3.3.2/Dockerfile
+++ b/3.3.2/Dockerfile
@@ -77,7 +77,7 @@ RUN wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar
     rgdal \
     rgeos \
     rlas \
-#    sf \
+    sf \
     sp \
     spacetime \
     spatstat \

--- a/3.3.3/Dockerfile
+++ b/3.3.3/Dockerfile
@@ -77,7 +77,7 @@ RUN wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar
     rgdal \
     rgeos \
     rlas \
-#    sf \
+    sf \
     sp \
     spacetime \
     spatstat \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
     libexpat1-dev \
     libfftw3-dev \
     libfreexl-dev \
-#  libgeos-dev \ # Need 3.5, this is 3.3
+	# geos 3.3.0:
+    libgeos-dev \
     libgsl0-dev \
     libglu1-mesa-dev \
     libhdf4-alt-dev \
@@ -36,15 +37,15 @@ RUN apt-get update \
     unixodbc-dev \
   && wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
   && tar -xf gdal-${GDAL_VERSION}.tar.gz \
-  && wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
-  && tar -xf geos-${GEOS_VERSION}.tar.bz2 \
+  #&& wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
+  #&& tar -xf geos-${GEOS_VERSION}.tar.bz2 \
 ## Install dependencies of gdal-$GDAL_VERSION
 ## && echo "deb-src http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
 ## Install libgeos \
-  && cd /geos* \
-  && ./configure \
-  && make \
-  && make install \
+  #&& cd /geos* \
+  #&& ./configure \
+  #&& make \
+  #&& make install \
 ## Configure options loosely based on homebrew gdal2 https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/Formula/gdal2.rb
   && cd /gdal* \
   && ./configure \


### PR DESCRIPTION
this PR enables sf, which with version 0.4-1 works again with GEOS versions older than 3.5.0; hence, I also outcommented the lines that install GEOS from source. This leaves us with a somewhat older GEOS, and some functions in sf that are not available (e.g., st_voronoi). Also, sf::st_makevalid needs a liblwgeom-dev more recent than in this distro, so that is not being picked up when compiling sf, which makes liblwgeom-dev a candidate to be removed from this Dockerfile collection.