### PR TITLE
Proposed changes to migrate 3.4.0/latest/devel to debian:stretch

### DIFF
--- a/3.4.0/Dockerfile
+++ b/3.4.0/Dockerfile
@@ -1,84 +1,33 @@
 FROM rocker/verse:3.4.0
 MAINTAINER "Carl Boettiger" cboettig@ropensci.org
 
-ENV GDAL_VERSION 2.1.3
-ENV GEOS_VERSION 3.5.1
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
-
 RUN apt-get update \
-##  && apt-get build-dep -y -o APT::Get::Build-Dep-Automatic=true libgdal-dev \
   && apt-get install -y --no-install-recommends \
     lbzip2 \
-    ## dev packages
-    libdap-dev \
-    libexpat1-dev \
     libfftw3-dev \
-    libfreexl-dev \
-#  libgeos-dev \ # Need 3.5, this is 3.3
+    libgdal-dev \
+    libgeos-dev \
     libgsl0-dev \
-    libglu1-mesa-dev \
     libhdf4-alt-dev \
     libhdf5-dev \
     liblwgeom-dev \
-    libkml-dev \
-    libnetcdf-dev \
     libproj-dev \
+    libnetcdf-dev \
     libsqlite3-dev \
     libssl-dev \
-    libtcl8.6 \
-    libtk8.6 \
-    libtiff5-dev \
     libudunits2-dev \
-    libxerces-c-dev \
-   ## runtime packages
-    netcdf-bin \
+    tk-dev \
     unixodbc-dev \
-  && wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
-  && tar -xf gdal-${GDAL_VERSION}.tar.gz \
-  && wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
-  && tar -xf geos-${GEOS_VERSION}.tar.bz2 \
-## Install dependencies of gdal-$GDAL_VERSION
-## && echo "deb-src http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
-## Install libgeos \
-  && cd /geos* \
-  && ./configure \
-  && make \
-  && make install \
-## Configure options loosely based on homebrew gdal2 https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/Formula/gdal2.rb
-  && cd /gdal* \
-  && ./configure \
-    --with-curl \
-    --with-dods-root=/usr \
-    --with-freexl \
-    --with-geos \
-    --with-geotiff \
-    --with-hdf4 \
-    --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
-    --with-libjson-c \
-    --with-netcdf \
-    --with-odbc \
-    ##
-    --without-grass \
-    --without-libgrass \
-  && make \
-  && make install \
-  && cd .. \
-  ## Cleanup gdal & geos installation
-  && rm -rf gdal-* geos-* \
-## Install R packages labeled "core" in Spatial taskview 
   && install2.r --error \
-    ## from CRAN
-    DCluster \
     RColorBrewer \
     RandomFields \
     classInt \
     deldir \
-    dggridR \
     gstat \
     lidR \
+    mapdata \
     maptools \
-    ncdf4 \
+    mapview \
     proj4 \
     raster \
     rgdal \
@@ -89,7 +38,7 @@ RUN apt-get update \
     spacetime \
     spatstat \
     spdep \
-    splancs \
     geoR \
+    geosphere \
     ## from bioconductor
     && R -e "BiocInstaller::biocLite('rhdf5')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     libgeos-dev \
     libgsl0-dev \
     libgl1-mesa-dev \
+    libglu1-mesa-dev \
     libhdf4-alt-dev \
     libhdf5-dev \
     liblwgeom-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     libgdal-dev \
     libgeos-dev \
     libgsl0-dev \
+    libgl1-mesa-dev \
     libhdf4-alt-dev \
     libhdf5-dev \
     liblwgeom-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,84 +1,33 @@
 FROM rocker/verse:latest
 MAINTAINER "Carl Boettiger" cboettig@ropensci.org
 
-ENV GDAL_VERSION 2.1.3
-ENV GEOS_VERSION 3.5.1
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
-
 RUN apt-get update \
-##  && apt-get build-dep -y -o APT::Get::Build-Dep-Automatic=true libgdal-dev \
   && apt-get install -y --no-install-recommends \
     lbzip2 \
-    ## dev packages
-    libdap-dev \
-    libexpat1-dev \
     libfftw3-dev \
-    libfreexl-dev \
-#  libgeos-dev \ # Need 3.5, this is 3.3
+    libgdal-dev \
+    libgeos-dev \
     libgsl0-dev \
-    libglu1-mesa-dev \
     libhdf4-alt-dev \
     libhdf5-dev \
     liblwgeom-dev \
-    libkml-dev \
-    libnetcdf-dev \
     libproj-dev \
+    libnetcdf-dev \
     libsqlite3-dev \
     libssl-dev \
-    libtcl8.6 \
-    libtk8.6 \
-    libtiff5-dev \
     libudunits2-dev \
-    libxerces-c-dev \
-   ## runtime packages
-    netcdf-bin \
+    tk-dev \
     unixodbc-dev \
-  && wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
-  && tar -xf gdal-${GDAL_VERSION}.tar.gz \
-  && wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
-  && tar -xf geos-${GEOS_VERSION}.tar.bz2 \
-## Install dependencies of gdal-$GDAL_VERSION
-## && echo "deb-src http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
-## Install libgeos \
-  && cd /geos* \
-  && ./configure \
-  && make \
-  && make install \
-## Configure options loosely based on homebrew gdal2 https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/Formula/gdal2.rb
-  && cd /gdal* \
-  && ./configure \
-    --with-curl \
-    --with-dods-root=/usr \
-    --with-freexl \
-    --with-geos \
-    --with-geotiff \
-    --with-hdf4 \
-    --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
-    --with-libjson-c \
-    --with-netcdf \
-    --with-odbc \
-    ##
-    --without-grass \
-    --without-libgrass \
-  && make \
-  && make install \
-  && cd .. \
-  ## Cleanup gdal & geos installation
-  && rm -rf gdal-* geos-* \
-## Install R packages labeled "core" in Spatial taskview 
   && install2.r --error \
-    ## from CRAN
-    DCluster \
     RColorBrewer \
     RandomFields \
     classInt \
     deldir \
-    dggridR \
     gstat \
     lidR \
+    mapdata \
     maptools \
-    ncdf4 \
+    mapview \
     proj4 \
     raster \
     rgdal \
@@ -89,7 +38,7 @@ RUN apt-get update \
     spacetime \
     spatstat \
     spdep \
-    splancs \
     geoR \
+    geosphere \
     ## from bioconductor
     && R -e "BiocInstaller::biocLite('rhdf5')"

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,17 @@ devel/Dockerfile: Dockerfile
 	export R_VERSION=3.4.0 && make update
 
 3.4.0: .PHONY
-	docker build -t geospatial:3.4.0 3.4.0
+	docker build -t rocker/geospatial:3.4.0 3.4.0
 3.3.3: .PHONY
-	docker build -t geospatial:3.3.3 3.3.3
+	docker build -t rocker/geospatial:3.3.3 3.3.3
 3.3.2: .PHONY
-	docker build -t geospatial:3.3.2 3.3.2
+	docker build -t rocker/geospatial:3.3.2 3.3.2
 3.3.1: .PHONY 
-	docker build -t geospatial:3.3.1 3.3.1
+	docker build -t rocker/geospatial:3.3.1 3.3.1
 latest: 
-	docker build -t geospatial .
+	docker build -t rocker/geospatial .
 devel: .PHONY 
-	docker build -t geospatial:devel devel 
+	docker build -t rocker/geospatial:devel devel 
 
 
 update:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,38 @@
 [![CircleCI](https://circleci.com/gh/rocker-org/geospatial.svg?style=svg)](https://circleci.com/gh/rocker-org/geospatial) [![license](https://img.shields.io/badge/license-GPLv2-blue.svg)](https://opensource.org/licenses/GPL-2.0)  [![](https://images.microbadger.com/badges/image/rocker/geospatial.svg)](https://microbadger.com/images/rocker/geospatial)  [![](https://img.shields.io/docker/pulls/rocker/geospatial.svg)](https://hub.docker.com/r/rocker/geospatial) [![](https://img.shields.io/docker/automated/rocker/geospatial.svg)](https://hub.docker.com/r/rocker/geospatial/builds)
 
 
-Docker-based Geospatial toolkit for R, built on versioned Rocker images
+Docker-based Geospatial toolkit for R, built on versioned Rocker images. 
+
+This image extends the [`rocker-versioned` stack](https://github.com/rocker-org/rocker-versioned) with geospatial-related tools, particularly those that can be difficult or slow to add on-the-fly.  As such, this image includes RStudio, the tidyverse packages, and `verse` libraries (notably LaTeX and JAVA environments).  Like the rest of the `rocker-versioned` stack, tags for specific recent versions, including the `latest` and `devel` tags, are also provided. Versions older than the most recent will install R packages from an MRAN snapshot, and may not provide all the same packages as seen on the most recent versions.    
+
+## Packages
 
 
+The packages included in this image are not meant to provide a kitchen-sink of all geo-spatially related R packages, see the [Spatial Task View](https://cran.r-project.org/web/views/Spatial.html) and [SpatioTemporal Task View](https://cran.r-project.org/web/views/SpatioTemporal.html) on CRAN.  This image seeks to provide a more opinionated collection of packages, prioritizing those packages that can be slow or tricky to install due to compiled code and external dependencies, and with an emphasis on more general-purpose libaries and classes.  
 
+Please note that many additional geospatial (and other) packages are pulled in as dependencies of this list and thus can also be found on the image.  Feel free to request any additional packages you would like to see added by [filing an issue](https://github.com/rocker-org/geospatial/issues). 
+
+Package       | Maintainer| Description 
+--------------|-----------|----------------------------------
+RColorBrewer  |           | Colors for maps and other plots
+RandomFields  |Schlather  | Methods for the inference on and the simulation of Gaussian fields, and simulation of extreme value random fields.
+classInt      | Bivand    | Selected commonly used methods for choosing univariate class intervals for mapping or other graphics purposes.
+deldir        | Turner    | Delaunay Triangulation and Dirichlet (Voronoi) Tessellation 
+gstat         | Pebesma   | Spatial and Spatio-Temporal Geostatistical Modelling, Prediction and Simulation
+lidR          | Roussel   | Airborne LiDAR (Light Detection and Ranging) interface for data manipulation and visualization. Read/write 'las' and 'laz' file
+mapdata       | Deckmyn   | Extra map data for the `maps` package (originally from S)
+maptools      | Bivand    | Set of tools for manipulating and reading geographic data, in particular ESRI Shapefiles.  (See `rgdal` and `sf` for more comprehensive I/O)
+mapview       | Appelhans | sf-compatible interactive map viewer, extends leaflet  
+proj4         | Urbanek   | A simple interface to lat/long projection and datum transformation.  See `sf` implementation as well. 
+raster        | Hijmans   | Reading, writing, manipulating, analyzing and modeling of gridded spatial data.
+rgdal         | Bivand    | Interface to GDAL, I/O formats. See `sf` for more recent implementation
+rgeos         | Bivand    | Interface to GEOS (geometry operations). See `sf` for more recent implementation
+sf            | Pebesma   | Simple-features oriented replacement for sp, rgdal, rgeos, and proj4 libraries, includes dplyr-style methods.
+sp            | Pebesma   | Original & widely used spatial object class
+spacetime     | Pebesma   | Classes and Methods for Spatio-Temporal Data
+spatstat      | Baddeley  | Large spatial statistics package: Spatial Point Pattern Analysis, Model-Fitting, Simulation, Tests
+spdep         | Bivand    | Spatial Dependence: Weighting Schemes, Statistics and Models
+geoR          | Ribeiro   | Geostatistical analysis including traditional, likelihood-based and Bayesian methods.
+geosphere     | Hijmans   | Spherical trigonometry for geographic applications. That is, compute distances and related measures for angular (longitude/latitude) locations. 
+
+ 

--- a/devel/Dockerfile
+++ b/devel/Dockerfile
@@ -1,84 +1,33 @@
 FROM rocker/verse:devel
 MAINTAINER "Carl Boettiger" cboettig@ropensci.org
 
-ENV GDAL_VERSION 2.1.3
-ENV GEOS_VERSION 3.5.1
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-
-
 RUN apt-get update \
-##  && apt-get build-dep -y -o APT::Get::Build-Dep-Automatic=true libgdal-dev \
   && apt-get install -y --no-install-recommends \
     lbzip2 \
-    ## dev packages
-    libdap-dev \
-    libexpat1-dev \
     libfftw3-dev \
-    libfreexl-dev \
-#  libgeos-dev \ # Need 3.5, this is 3.3
+    libgdal-dev \
+    libgeos-dev \
     libgsl0-dev \
-    libglu1-mesa-dev \
     libhdf4-alt-dev \
     libhdf5-dev \
     liblwgeom-dev \
-    libkml-dev \
-    libnetcdf-dev \
     libproj-dev \
+    libnetcdf-dev \
     libsqlite3-dev \
     libssl-dev \
-    libtcl8.6 \
-    libtk8.6 \
-    libtiff5-dev \
     libudunits2-dev \
-    libxerces-c-dev \
-   ## runtime packages
-    netcdf-bin \
+    tk-dev \
     unixodbc-dev \
-  && wget http://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz \
-  && tar -xf gdal-${GDAL_VERSION}.tar.gz \
-  && wget http://download.osgeo.org/geos/geos-${GEOS_VERSION}.tar.bz2 \
-  && tar -xf geos-${GEOS_VERSION}.tar.bz2 \
-## Install dependencies of gdal-$GDAL_VERSION
-## && echo "deb-src http://deb.debian.org/debian jessie main" >> /etc/apt/sources.list \
-## Install libgeos \
-  && cd /geos* \
-  && ./configure \
-  && make \
-  && make install \
-## Configure options loosely based on homebrew gdal2 https://github.com/OSGeo/homebrew-osgeo4mac/blob/master/Formula/gdal2.rb
-  && cd /gdal* \
-  && ./configure \
-    --with-curl \
-    --with-dods-root=/usr \
-    --with-freexl \
-    --with-geos \
-    --with-geotiff \
-    --with-hdf4 \
-    --with-hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial \
-    --with-libjson-c \
-    --with-netcdf \
-    --with-odbc \
-    ##
-    --without-grass \
-    --without-libgrass \
-  && make \
-  && make install \
-  && cd .. \
-  ## Cleanup gdal & geos installation
-  && rm -rf gdal-* geos-* \
-## Install R packages labeled "core" in Spatial taskview 
   && install2.r --error \
-    ## from CRAN
-    DCluster \
     RColorBrewer \
     RandomFields \
     classInt \
     deldir \
-    dggridR \
     gstat \
     lidR \
+    mapdata \
     maptools \
-    ncdf4 \
+    mapview \
     proj4 \
     raster \
     rgdal \
@@ -89,7 +38,7 @@ RUN apt-get update \
     spacetime \
     spatstat \
     spdep \
-    splancs \
     geoR \
+    geosphere \
     ## from bioconductor
     && R -e "BiocInstaller::biocLite('rhdf5')"


### PR DESCRIPTION
- Installs GDAL and GEOS from apt repos rather than compiling from source.
- Some fine tuning of package list
- Add readme with some overview of packages included and general rationale for them.