### PR TITLE
Explicitly add lwgeom to install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,6 @@ RUN apt-get update \
     spdep \
     geoR \
     geosphere \
+    lwgeom \
     ## from bioconductor
     && R -e "BiocManager::install('rhdf5')"


### PR DESCRIPTION
It does not seem to install properly on the geocompr builds. See here: https://github.com/Robinlovelace/geocompr/issues/361

Will be interesting to see if this passes.